### PR TITLE
fix: hide picker before positioning it to avoid flickering

### DIFF
--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -46,8 +46,13 @@ const handleInput = (self: VanillaCalendar) => {
 		document.body.appendChild(self.HTMLElement);
 		firstInit = false;
 
+		// because of a positioning delay, it might flicker for a short period
+		// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
+		self.HTMLElement.style.visibility = 'hidden';
+
 		setTimeout(() => {
 			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
 			self.show();
 		}, 0);
 		reset(self, {


### PR DESCRIPTION
- because the auto-positioning is done inside a setTimeout delay, it could be flickering to the user's eye, to avoid this we could hide the picker and show it back only after it's positioned to the new location which should in theory remove the flickering.