### PR TITLE
fix: make sure to create picker before calling update

### DIFF
--- a/demo/pages/input/index.html
+++ b/demo/pages/input/index.html
@@ -12,6 +12,7 @@
 	<body class="font-sans bg-white bg-light-mode text-slate-900 min-h-screen container mx-auto text-center flex flex-col items-center py-12 dark:bg-slate-900 dark:bg-dark-mode dark:text-white">
 		<h1 class="block mb-7 text-6xl font-extrabold">Vanilla Calendar</h1>
 		<p class="text-lg mb-12 dark:text-slate-400">A pure JavaScript date and time picker using TypeScript so it supports any JS framework and library.</p>
+		<button id="set-date" type="button" class="mb-7 w-64 border-gray-200 border-2">Set Date</button>
 		<label>
 			<div>Datepicker tag 'input'</div>
 			<input id="calendar-input" class="input" name="calendar" type="text" readonly />

--- a/demo/pages/input/main.ts
+++ b/demo/pages/input/main.ts
@@ -52,4 +52,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	const calendarDiv = new VanillaCalendar('#calendar-div', configDiv);
 	calendarDiv.init();
+
+	document.querySelector('#set-date')?.addEventListener('click', () => {
+		calendarInput.settings.selected = {
+			dates: ['2023-04-07'],
+			month: 3,
+			year: 2023,
+		};
+		calendarInput.update({
+			dates: true,
+			month: true,
+			year: true,
+		});
+		calendarInput.HTMLInputElement!.value = '2023-04-07';
+	});
 });

--- a/package/src/scripts/default.ts
+++ b/package/src/scripts/default.ts
@@ -18,6 +18,7 @@ import type {
 
 export default class DefaultOptionsCalendar {
 	isInit = false;
+	isInputInit = false;
 	input = false;
 	type: TypesCalendar = 'default';
 	months = 2;

--- a/package/src/scripts/handles/handleInput.ts
+++ b/package/src/scripts/handles/handleInput.ts
@@ -1,66 +1,10 @@
 import { VanillaCalendar } from '@src/vanilla-calendar';
-import handleClick from '@scripts/handles/handleClick';
-import reset from '@scripts/reset';
-import { IVisibility, CSSClasses } from '@src/types';
-import { findBestPickerPosition } from '../helpers/position';
-
-const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
-	if (input) {
-		const pos = position === 'auto'
-			? findBestPickerPosition(input, calendar)
-			: position;
-
-		const getPosition = {
-			top: -calendar.offsetHeight,
-			bottom: input.offsetHeight,
-			left: 0,
-			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
-			right: input.offsetWidth - calendar.offsetWidth,
-		};
-
-		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
-		const XPosition = !Array.isArray(pos) ? pos : pos[1];
-
-		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
-
-		const inputRect = input.getBoundingClientRect();
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-		const top = inputRect.top + scrollTop + getPosition[YPosition];
-		const left = inputRect.left + scrollLeft + getPosition[XPosition];
-
-		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
-	}
-};
+import { createCalendarToInput } from '@scripts/helpers/createCalendarToInput';
+import { setPositionCalendar } from '@scripts/helpers/position';
 
 const handleInput = (self: VanillaCalendar) => {
-	let firstInit = true;
 	const cleanup: Array<() => void> = [];
 	self.HTMLInputElement = self.HTMLElement as HTMLInputElement;
-
-	const createCalendarToInput = () => {
-		const calendar = document.createElement('div');
-		calendar.className = `${self.CSSClasses.calendar} ${self.CSSClasses.calendarToInput} ${self.CSSClasses.calendarHidden}`;
-		self.HTMLElement = calendar;
-		document.body.appendChild(self.HTMLElement);
-		firstInit = false;
-
-		// because of a positioning delay, it might flicker for a short period
-		// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
-		self.HTMLElement.style.visibility = 'hidden';
-
-		setTimeout(() => {
-			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
-			self.HTMLElement.style.visibility = 'visible';
-			self.show();
-		}, 0);
-		reset(self, {
-			year: true, month: true, dates: true, holidays: true, time: true,
-		});
-		if (self.actions.initCalendar) self.actions.initCalendar(self);
-		return handleClick(self);
-	};
 
 	const handleResize = () => setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
 
@@ -72,10 +16,11 @@ const handleInput = (self: VanillaCalendar) => {
 	};
 
 	self.HTMLInputElement.addEventListener('click', () => {
-		if (firstInit) {
-			cleanup.push(createCalendarToInput());
+		if (!self.isInputInit) {
+			cleanup.push(createCalendarToInput(self));
 		} else {
 			setPositionCalendar(self.HTMLInputElement, self.HTMLElement, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
 			self.show();
 		}
 		window.addEventListener('resize', handleResize);

--- a/package/src/scripts/helpers/createCalendarToInput.ts
+++ b/package/src/scripts/helpers/createCalendarToInput.ts
@@ -1,0 +1,29 @@
+import { VanillaCalendar } from '@src/vanilla-calendar';
+import handleClick from '@scripts/handles/handleClick';
+import { setPositionCalendar } from '@scripts/helpers/position';
+import reset from '@scripts/reset';
+
+export const createCalendarToInput = (self: VanillaCalendar, isVisible = true) => {
+	self.isInputInit = true;
+	const calendar = document.createElement('div');
+	calendar.className = `${self.CSSClasses.calendar} ${self.CSSClasses.calendarToInput} ${self.CSSClasses.calendarHidden}`;
+	self.HTMLElement = calendar;
+	document.body.appendChild(self.HTMLElement);
+
+	// because of a positioning delay, it might flicker for a short period
+	// we can hide the picker, reposition it, and finally show it back to avoid flickering because of the positioning delay below
+	self.HTMLElement.style.visibility = 'hidden';
+
+	if (isVisible) {
+		queueMicrotask(() => {
+			setPositionCalendar(self.HTMLInputElement, calendar, self.settings.visibility.positionToInput, self.CSSClasses);
+			self.HTMLElement.style.visibility = 'visible';
+			self.show();
+		});
+	}
+	reset(self, {
+		year: true, month: true, dates: true, holidays: true, time: true,
+	});
+	if (self.actions.initCalendar) self.actions.initCalendar(self);
+	return handleClick(self);
+};

--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -1,4 +1,4 @@
-import { HtmlElementPosition } from '@src/types';
+import { CSSClasses, IVisibility, HtmlElementPosition } from '@src/types';
 
 type Position = 'center' | 'left' | 'right';
 type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
@@ -133,3 +133,33 @@ export function findBestPickerPosition(input: HTMLInputElement, calendar: HTMLEl
 
 	return position;
 }
+
+export const setPositionCalendar = (input: HTMLInputElement | undefined, calendar: HTMLElement, position: IVisibility['positionToInput'], css: CSSClasses) => {
+	if (input) {
+		const pos = position === 'auto'
+			? findBestPickerPosition(input, calendar)
+			: position;
+
+		const getPosition = {
+			top: -calendar.offsetHeight,
+			bottom: input.offsetHeight,
+			left: 0,
+			center: input.offsetWidth / 2 - calendar.offsetWidth / 2,
+			right: input.offsetWidth - calendar.offsetWidth,
+		};
+
+		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
+		const XPosition = !Array.isArray(pos) ? pos : pos[1];
+
+		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+
+		const inputRect = input.getBoundingClientRect();
+		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+		const scrollTop = window.scrollY || document.documentElement.scrollTop;
+
+		const top = inputRect.top + scrollTop + getPosition[YPosition];
+		const left = inputRect.left + scrollLeft + getPosition[XPosition];
+
+		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
+	}
+};

--- a/package/src/scripts/update.ts
+++ b/package/src/scripts/update.ts
@@ -1,5 +1,6 @@
 import { IReset } from '@src/types';
 import { VanillaCalendar } from '@src/vanilla-calendar';
+import { createCalendarToInput } from '@scripts/helpers/createCalendarToInput';
 import messages from '@scripts/helpers/getMessages';
 import reset from '@scripts/reset';
 
@@ -12,6 +13,9 @@ const update = (self: VanillaCalendar, {
 }: IReset = {}) => {
 	if (!self.isInit) throw new Error(messages.notInit);
 
+	if (self.input && !self.isInputInit) {
+		createCalendarToInput(self, false);
+	}
 	reset(self, {
 		year,
 		month,

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -248,4 +248,5 @@ export interface IVanillaCalendar {
 	readonly dateMin: Date;
 	readonly dateMax: Date;
 	readonly isInit: boolean;
+	readonly isInputInit: boolean;
 }


### PR DESCRIPTION
- calling `.update()` before the date picker is created was causing the input to be override as the new picker element and was also causing leakage when clicking the input because at that point 2 elements were now assigned as the picker container (input & new picker in the body)
- move the `createCalendarToInput` as a separate and exported function so that we can call it at the start of the `.update()` if the picker hasn't been created yet. 
- the only thing that I'm not entirely sure is the `cleanup` thing, if we create the picker outside of the `handleInput`, then we don't have access to that cleanup array, however I couldn't find how this cleanup is being called, so it might ok to leave it

below is the bug that was found, you can see the input being reassigned as the new picker (and the correct picker is not being created in the body because it thinks the input is the picker)

#### bug
ref [codesandbox](https://codesandbox.io/s/cold-hill-94mq9f?file=/calendar.ts:887-1214)

![image](https://github.com/uvarov-frontend/vanilla-calendar-pro/assets/643976/73785bbe-bfae-4cea-a5c7-34a25ff8da7c)

![brave_Yjlsbl4Vfw](https://github.com/uvarov-frontend/vanilla-calendar-pro/assets/643976/c8cf29ff-aca6-4735-a36e-3b41b65fc5aa)

#### after fix

now we can see that when we click the set date button, it will initialize (create) the picker in body and leave the input untouched as it should be

![brave_WxJ4vQSZqF](https://github.com/ghiscoding/vanilla-calendar-picker/assets/643976/4d78e4c8-b232-492d-b19a-b2664395ab1a)
