### PR TITLE
fix: there was unwanted picker offset by duplicate CSS classes

### DIFF
--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -4,9 +4,9 @@ type Position = 'center' | 'left' | 'right';
 type PositionList = ['bottom' | 'top', 'center' | 'left' | 'right'];
 
 /** Get HTML element offset with pure JS */
-export function getOffset(elm?: HTMLElement | null): HtmlElementPosition | undefined {
+export function getOffset(elm?: HTMLElement | null): HtmlElementPosition {
 	if (!elm || !elm.getBoundingClientRect) {
-		return undefined;
+		return { top: 0, bottom: 0, left: 0, right: 0 };
 	}
 	const box = elm.getBoundingClientRect();
 	const docElem = document.documentElement;
@@ -151,14 +151,17 @@ export const setPositionCalendar = (input: HTMLInputElement | undefined, calenda
 		const YPosition = !Array.isArray(pos) ? 'bottom' : pos[0];
 		const XPosition = !Array.isArray(pos) ? pos : pos[1];
 
-		calendar.classList.add(YPosition === 'bottom' ? css.calendarToInputBottom : css.calendarToInputTop);
+		if (YPosition === 'bottom') {
+			calendar.classList.remove(css.calendarToInputTop);
+			calendar.classList.add(css.calendarToInputBottom);
+		} else {
+			calendar.classList.remove(css.calendarToInputBottom);
+			calendar.classList.add(css.calendarToInputTop);
+		}
 
-		const inputRect = input.getBoundingClientRect();
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-		const top = inputRect.top + scrollTop + getPosition[YPosition];
-		const left = inputRect.left + scrollLeft + getPosition[XPosition];
+		const { top: offsetTop, left: offsetLeft } = getOffset(input);
+		const top = offsetTop + getPosition[YPosition];
+		const left = offsetLeft + getPosition[XPosition];
 
 		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
 	}


### PR DESCRIPTION
- I found an issue with the `auto` position of the calendar picker after repositioning multiple times, the issue came from the fact that we should only keep 1 CSS class at all time, it should either `vanilla-calendar_to-input_bottom` or `vanilla-calendar_to-input_top` but not both because that causes an unwanted offset
- we can see below the issue, when we start on the 1st run, we have a little offset (picker is slightly lower than the input with a +4px offset from the top), but when we toggle bottom/top/bottom, we then see that our offset is now inversed since it is no longer below the input but over the input (the offset changed from bottom +4px to -4px because we kept the unwanted duplicate CSS class when we should only keep 1 CSS class)

![brave_RbfJWKbH1h](https://github.com/user-attachments/assets/9d4428f3-c059-461c-943d-e92722cfceea)
