### PR TITLE
fix: make sure picker position is never outside body viewport

### DIFF
--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -161,7 +161,17 @@ export const setPositionCalendar = (input: HTMLInputElement | undefined, calenda
 
 		const { top: offsetTop, left: offsetLeft } = getOffset(input);
 		const top = offsetTop + getPosition[YPosition];
-		const left = offsetLeft + getPosition[XPosition];
+		let left = offsetLeft + getPosition[XPosition];
+
+		// make sure the new position is not outside the viewport,
+		// if so then change position to have enough space to show full picker
+		const { vw } = getViewportDimensions();
+		if (left + calendar.clientWidth > vw) {
+			const scrollbarWidth = (window.innerWidth - document.body.clientWidth);
+			left = vw - calendar.clientWidth - scrollbarWidth;
+		} else if (left < 0) {
+			left = 0;
+		}
 
 		Object.assign(calendar.style, { left: `${left}px`, top: `${top}px` });
 	}


### PR DESCRIPTION
- as reported by a user in this external [issue](https://github.com/ghiscoding/slickgrid-react/issues/391), if the input is a bit outside of the viewport (ie, when the div is scrolled) then the picker was being positioned to an invalid coordinate because the picker is always appended to the document body which doesn't usually have any scroll and when that happened the calendar picker wasn't showing correctly because it also uses CSS flexbox and the picker started to stretch because it didn't have enough space in the body... so we can simply reposition it to be exactly on the body side (body width - picker picker becomes the new X coordinate)
- so because it doesn't have enough space and because it uses flexbox, it was stretching the picker making the 2 months as top/bottom as seen below which is not the behavior we expect. So as mentioned above, if we set the picker a valid coordinate then it doesn't need to stretch and the picker stays visually correct, which is what this PR does by making sure it's never outside the body viewport

notice below that the input or further on the right, which is why the picker is now being stretched

![image](https://github.com/user-attachments/assets/739a84ec-aff2-41b4-8e9f-7c5021c16fe9)
