### PR TITLE
Fix: set minimum width for the calendar 300

### DIFF
--- a/package/src/scripts/helpers/position.ts
+++ b/package/src/scripts/helpers/position.ts
@@ -166,9 +166,11 @@ export const setPositionCalendar = (input: HTMLInputElement | undefined, calenda
 		// make sure the new position is not outside the viewport,
 		// if so then change position to have enough space to show full picker
 		const { vw } = getViewportDimensions();
-		if (left + calendar.clientWidth > vw) {
+		const calendarWidth = calendar.clientWidth === 0 ? 300 : calendar.clientWidth
+
+		if (left + calendarWidth > vw) {
 			const scrollbarWidth = (window.innerWidth - document.body.clientWidth);
-			left = vw - calendar.clientWidth - scrollbarWidth;
+			left = vw - calendarWidth - scrollbarWidth;
 		} else if (left < 0) {
 			left = 0;
 		}


### PR DESCRIPTION
**What**
Add 300 as minimum value for the width in the calendar div

**Why**
`calendar.clientWidth` was returning `0`